### PR TITLE
Bugfix support multiple cookies per single 'Cookie' header

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -77,11 +77,14 @@ class Request extends EventEmitter
         }
         $cookies = $headers["cookie"];
         foreach($cookies as $cookie) {
-            $nameValuePair = explode('=', $cookie, 2);
-            if (count($nameValuePair) === 2) {
-                $k = urldecode($nameValuePair[0]);
-                if($key == $k)
-                    return urldecode($nameValuePair[1]);
+            $params = explode(';', $cookie);
+            foreach ($params as $param) {
+                $nameValuePair = explode('=', $param, 2);
+                if (count($nameValuePair) === 2) {
+                    $k = urldecode($nameValuePair[0]);
+                    if($key == $k)
+                        return urldecode($nameValuePair[1]);
+                }
             }
         }
     }


### PR DESCRIPTION
According to RFC6265 'Cookie' contains semicolon separated list of cookie pairs https://tools.ietf.org/html/rfc6265#section-4.2.1