### PR TITLE
Persist session properly on login with not cookies

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -17,6 +17,12 @@ class Request extends EventEmitter
     private $data = [];
 
     /**
+     * @var string - used to keep newly generated sessionId
+     * and also optimizaton to not parse cookies each time
+     */
+    private $sessionId;
+
+    /**
      * @param ReactHttpRequest $httpRequest
      */
     public function __construct(ReactHttpRequest $httpRequest)
@@ -94,7 +100,18 @@ class Request extends EventEmitter
 
     public function getSessionId()
     {
-        return $this->getCookie("id");
+        if (is_null($this->sessionId)) {
+            $this->sessionId = $this->getCookie("id");
+        }
+        return $this->sessionId;
+    }
+
+    /**
+     * Used for new requests for which session was generated
+     */
+    public function setSessionId($newSessionId)
+    {
+        $this->sessionId = $newSessionId;
     }
 
     /**

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -15,7 +15,8 @@ class Session
     public function start($request, $response)
     {
         if(!$request->hasSession()) {
-            $r = rand();
+            $r = strval(rand());
+            $request->setSessionId($r);
             $file = $this->getSessionFile($request);
             touch($file);
             $response->addCookie("id", $r);


### PR DESCRIPTION
### Problem 

When client do login with no cookies, server doesn't properly keep session because server track session by cookie only and don't store any session params for newley logged in user

### Proposed solution

 - Introduce new api `Request->setSessionId(string sessionId)` which will be called at the same time when `$response->addCookie("id", $sessionId)` called
 - Modify `Request->getSessionId()` to return it local sessionId value if it exists